### PR TITLE
Move to Spring Boot 2.3.3.RELEASE.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development
 
-For developing java-beetle and running the tests two things are requires:
+For developing java-beetle and running the tests two things are required:
 
 * a JDK installation (11+)
 * a docker/docker-compose installation

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
-                    <version>2.3.3.RELEASE</version>
+                    <version>2.2.7.RELEASE</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>9</maven.compiler.release>
-        <spring.version>2.2.1.RELEASE</spring.version>
+        <spring.version>2.3.3.RELEASE</spring.version>
     </properties>
 
     <modules>
@@ -186,7 +186,7 @@
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
-                    <version>2.2.7.RELEASE</version>
+                    <version>2.3.3.RELEASE</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>9</maven.compiler.release>
         <spring.version>2.3.3.RELEASE</spring.version>
+        <spring.rabbit.test.version>2.2.10.RELEASE</spring.rabbit.test.version>
     </properties>
 
     <modules>
@@ -186,7 +187,7 @@
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
-                    <version>2.2.7.RELEASE</version>
+                    <version>2.3.3.RELEASE</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/spring-integration/pom.xml
+++ b/spring-integration/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.springframework.amqp</groupId>
             <artifactId>spring-rabbit-test</artifactId>
-            <version>${spring.version}</version>
+            <version>${spring.rabbit.test.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spring-integration/src/main/java/com/xing/beetle/spring/BeetleAutoConfiguration.java
+++ b/spring-integration/src/main/java/com/xing/beetle/spring/BeetleAutoConfiguration.java
@@ -66,7 +66,7 @@ public class BeetleAutoConfiguration {
           .asInt(Duration::getSeconds)
           .to(factory::setRequestedHeartbeat);
       RabbitProperties.Ssl ssl = properties.getSsl();
-      if (ssl.isEnabled()) {
+      if (ssl.determineEnabled()) {
         factory.setUseSSL(true);
         map.from(ssl::getAlgorithm).whenNonNull().to(factory::setSslAlgorithm);
         map.from(ssl::getKeyStoreType).to(factory::setKeyStoreType);


### PR DESCRIPTION
RabbitProperties.Ssl.isEnabled() method is gone in Spring Boot version 2.3.3.

Should we make an official announcement about this?