### PR TITLE
Use proper redis keys

### DIFF
--- a/beetle-core/src/main/java/com/xing/beetle/amqp/BeetleMessageAdapter.java
+++ b/beetle-core/src/main/java/com/xing/beetle/amqp/BeetleMessageAdapter.java
@@ -34,7 +34,7 @@ public class BeetleMessageAdapter implements MessageAdapter<Delivery> {
   }
 
   @Override
-  public String keyOf(Delivery message) {
+  public String messageId(Delivery message) {
     return message.getProperties().getMessageId();
   }
 

--- a/beetle-core/src/main/java/com/xing/beetle/amqp/BeetleMessageAdapter.java
+++ b/beetle-core/src/main/java/com/xing/beetle/amqp/BeetleMessageAdapter.java
@@ -13,12 +13,15 @@ import static java.util.Objects.requireNonNull;
 public class BeetleMessageAdapter implements MessageAdapter<Delivery> {
 
   private final Channel channel;
+  private final String keyPrefix;
   private final boolean needToAck;
   private final boolean rejectAndRequeue;
   private static final int FLAG_REDUNDANT = 1;
 
-  BeetleMessageAdapter(Channel channel, boolean needToAck, boolean rejectAndRequeue) {
+  BeetleMessageAdapter(
+      Channel channel, String queueName, boolean needToAck, boolean rejectAndRequeue) {
     this.channel = requireNonNull(channel);
+    this.keyPrefix = "msgid:" + queueName + ":";
     this.needToAck = needToAck;
     this.rejectAndRequeue = rejectAndRequeue;
   }
@@ -36,7 +39,7 @@ public class BeetleMessageAdapter implements MessageAdapter<Delivery> {
 
   @Override
   public String keyOf(Delivery message) {
-    return message.getProperties().getMessageId();
+    return keyPrefix + message.getProperties().getMessageId();
   }
 
   @Override

--- a/beetle-core/src/main/java/com/xing/beetle/amqp/MultiPlexingConnection.java
+++ b/beetle-core/src/main/java/com/xing/beetle/amqp/MultiPlexingConnection.java
@@ -144,7 +144,7 @@ public class MultiPlexingConnection implements DefaultConnection.Decorator {
                   // beetle client have the full control
                   BeetleMessageAdapter beetleMessageAdapter =
                       new BeetleMessageAdapter(
-                          consumerTags.get(consumerTag), autoAck, rejectAndRequeue);
+                          consumerTags.get(consumerTag), queue, autoAck, rejectAndRequeue);
 
                   Delivery message = new Delivery(envelope, properties, body);
                   if (beetleMessageAdapter.keyOf(message) != null) {

--- a/beetle-core/src/main/java/com/xing/beetle/amqp/MultiPlexingConnection.java
+++ b/beetle-core/src/main/java/com/xing/beetle/amqp/MultiPlexingConnection.java
@@ -144,7 +144,7 @@ public class MultiPlexingConnection implements DefaultConnection.Decorator {
                   // beetle client have the full control
                   BeetleMessageAdapter beetleMessageAdapter =
                       new BeetleMessageAdapter(
-                          consumerTags.get(consumerTag), queue, autoAck, rejectAndRequeue);
+                          consumerTags.get(consumerTag), autoAck, rejectAndRequeue);
 
                   Delivery message = new Delivery(envelope, properties, body);
                   if (beetleMessageAdapter.keyOf(message) != null) {
@@ -162,7 +162,7 @@ public class MultiPlexingConnection implements DefaultConnection.Decorator {
                         };
 
                     deduplicator.handle(
-                        message, beetleMessageAdapter, dedup_handle_delivery_called);
+                        message, queue, beetleMessageAdapter, dedup_handle_delivery_called);
                     return;
                   }
                 }
@@ -172,7 +172,6 @@ public class MultiPlexingConnection implements DefaultConnection.Decorator {
           };
 
       Consumer consumer = tagMapping.createConsumerDecorator(callBackForAll, channel);
-      ;
       setDefaultConsumer(consumer);
 
       return channel.basicConsume(

--- a/beetle-core/src/main/java/com/xing/beetle/amqp/MultiPlexingConnection.java
+++ b/beetle-core/src/main/java/com/xing/beetle/amqp/MultiPlexingConnection.java
@@ -147,7 +147,7 @@ public class MultiPlexingConnection implements DefaultConnection.Decorator {
                           consumerTags.get(consumerTag), autoAck, rejectAndRequeue);
 
                   Delivery message = new Delivery(envelope, properties, body);
-                  if (beetleMessageAdapter.keyOf(message) != null) {
+                  if (beetleMessageAdapter.messageId(message) != null) {
 
                     MessageListener<Delivery> dedup_handle_delivery_called =
                         new MessageListener<>() {

--- a/beetle-core/src/main/java/com/xing/beetle/dedup/api/MessageListener.java
+++ b/beetle-core/src/main/java/com/xing/beetle/dedup/api/MessageListener.java
@@ -1,6 +1,5 @@
 package com.xing.beetle.dedup.api;
 
-import java.io.IOException;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 
@@ -30,7 +29,7 @@ public interface MessageListener<M> {
     logger().log(Level.WARNING, reason);
   }
 
-  default void onRequeued(M message) throws IOException {}
+  default void onRequeued(M message) {}
 
   default void onFailure(M message, String reason) {
     logger().log(Level.WARNING, reason);

--- a/beetle-core/src/main/java/com/xing/beetle/dedup/spi/Deduplicator.java
+++ b/beetle-core/src/main/java/com/xing/beetle/dedup/spi/Deduplicator.java
@@ -32,25 +32,25 @@ public interface Deduplicator {
   String[] keySuffixes =
       new String[] {MUTEX, STATUS, ACK_COUNT, TIMEOUT, DELAY, ATTEMPTS, EXCEPTIONS, EXPIRES};
 
-  boolean tryAcquireMutex(String messageId, int secondsToExpire);
+  boolean tryAcquireMutex(String key, int secondsToExpire);
 
-  void releaseMutex(String messageId);
+  void releaseMutex(String key);
 
-  void complete(String messageId);
+  void complete(String key);
 
-  boolean completed(String messageId);
+  boolean completed(String key);
 
-  boolean delayed(String messageId);
+  boolean delayed(String key);
 
-  void setDelay(String messageId, long timestamp);
+  void setDelay(String key, long timestamp);
 
-  long incrementAttempts(String messageId);
+  long incrementAttempts(String key);
 
-  long incrementExceptions(String messageId);
+  long incrementExceptions(String key);
 
-  long incrementAckCount(String messageId);
+  long incrementAckCount(String key);
 
-  void deleteKeys(String messageId);
+  void deleteKeys(String key);
 
   BeetleAmqpConfiguration getBeetleAmqpConfiguration();
 
@@ -75,8 +75,9 @@ public interface Deduplicator {
     }
   }
 
-  default <M> void handle(M message, MessageAdapter<M> adapter, MessageListener<M> listener) {
-    String key = adapter.keyOf(message);
+  default <M> void handle(
+      M message, String queueName, MessageAdapter<M> adapter, MessageListener<M> listener) {
+    String key = "msgid:" + queueName + ":" + adapter.keyOf(message);
     // check if the message is ancient or it was already completed.
     if (isExpired(message, adapter)) {
       dropMessage(

--- a/beetle-core/src/main/java/com/xing/beetle/dedup/spi/KeyValueStoreBasedDeduplicator.java
+++ b/beetle-core/src/main/java/com/xing/beetle/dedup/spi/KeyValueStoreBasedDeduplicator.java
@@ -41,18 +41,19 @@ public class KeyValueStoreBasedDeduplicator implements Deduplicator {
   }
 
   @Override
-  public boolean completed(String key) {
-    if (store.putIfAbsentTtl(
+  public boolean isComplete(String key) {
+    return store
+        .get(dedupKey(key, STATUS))
+        .map(value -> value.getAsString().equals("completed"))
+        .orElse(false);
+  }
+
+  @Override
+  public void init(String key) {
+    store.putIfAbsentTtl(
         dedupKey(key, STATUS),
         new Value("incomplete"),
-        beetleAmqpConfig.getBeetleRedisStatusKeyExpiryIntervalSeconds())) {
-      return false;
-    } else {
-      return store
-          .get(dedupKey(key, STATUS))
-          .map(value -> value.getAsString().equals("completed"))
-          .orElse(false);
-    }
+        beetleAmqpConfig.getBeetleRedisStatusKeyExpiryIntervalSeconds());
   }
 
   @Override

--- a/beetle-core/src/main/java/com/xing/beetle/dedup/spi/MessageAdapter.java
+++ b/beetle-core/src/main/java/com/xing/beetle/dedup/spi/MessageAdapter.java
@@ -4,7 +4,7 @@ public interface MessageAdapter<M> {
 
   void drop(M message);
 
-  String keyOf(M message);
+  String messageId(M message);
 
   void requeue(M message);
 

--- a/beetle-core/src/test/java/com/xing/beetle/MultiPlexingConnectionIT.java
+++ b/beetle-core/src/test/java/com/xing/beetle/MultiPlexingConnectionIT.java
@@ -5,7 +5,6 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.ConnectionFactory;
 import com.xing.beetle.amqp.BeetleAmqpConfiguration;
 import com.xing.beetle.amqp.MultiPlexingConnection;
-
 import com.xing.beetle.dedup.spi.Deduplicator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -52,9 +51,12 @@ public class MultiPlexingConnectionIT {
               public void complete(String messageId) {}
 
               @Override
-              public boolean completed(String messageId) {
+              public boolean isComplete(String messageId) {
                 return false;
               }
+
+              @Override
+              public void init(String key) {}
 
               @Override
               public boolean delayed(String messageId) {

--- a/beetle-core/src/test/java/com/xing/beetle/NewBeetleAcceptanceBeetleIT.java
+++ b/beetle-core/src/test/java/com/xing/beetle/NewBeetleAcceptanceBeetleIT.java
@@ -39,7 +39,7 @@ class NewBeetleAcceptanceBeetleIT extends BaseBeetleIT {
 
   @NotNull
   private static GenericContainer startRedisContainer() {
-    GenericContainer localRedis = new GenericContainer("redis:3.0.2").withExposedPorts(6379);
+    GenericContainer localRedis = new GenericContainer("redis:4.0.14").withExposedPorts(6379);
     localRedis.start();
     return localRedis;
   }

--- a/beetle-core/src/test/java/com/xing/beetle/NewBeetleAcceptanceBeetleIT.java
+++ b/beetle-core/src/test/java/com/xing/beetle/NewBeetleAcceptanceBeetleIT.java
@@ -4,7 +4,6 @@ import com.rabbitmq.client.*;
 import com.xing.beetle.amqp.BeetleAmqpConfiguration;
 import com.xing.beetle.amqp.BeetleConnectionFactory;
 import com.xing.beetle.util.ExceptionSupport;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.containers.GenericContainer;
@@ -28,7 +27,6 @@ class NewBeetleAcceptanceBeetleIT extends BaseBeetleIT {
     redisServer = getRedisAddress(redis);
   }
 
-  @NotNull
   private static String getRedisAddress(GenericContainer redisContainer) {
     return String.join(
         ":",
@@ -37,7 +35,6 @@ class NewBeetleAcceptanceBeetleIT extends BaseBeetleIT {
         });
   }
 
-  @NotNull
   private static GenericContainer startRedisContainer() {
     GenericContainer localRedis = new GenericContainer("redis:4.0.14").withExposedPorts(6379);
     localRedis.start();

--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
-                <version>1.14.1</version>
+                <version>1.15.0-rc2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/spring-integration/src/main/java/com/xing/beetle/spring/SpringMessageAdapter.java
+++ b/spring-integration/src/main/java/com/xing/beetle/spring/SpringMessageAdapter.java
@@ -34,7 +34,7 @@ class SpringMessageAdapter implements MessageAdapter<Message> {
   }
 
   @Override
-  public String keyOf(Message message) {
+  public String messageId(Message message) {
     return message.getMessageProperties().getMessageId();
   }
 

--- a/spring-integration/src/main/java/com/xing/beetle/spring/SpringMessageAdapter.java
+++ b/spring-integration/src/main/java/com/xing/beetle/spring/SpringMessageAdapter.java
@@ -47,12 +47,13 @@ class SpringMessageAdapter implements MessageAdapter<Message> {
       return ((Number) expiresAt).longValue();
     } else if (expiresAt instanceof String) {
       return Long.parseLong((String) expiresAt);
-    } else try {
-      return Long.parseLong(expiresAt.toString());
-    } catch (NumberFormatException e) {
-      throw new IllegalArgumentException(
-              "Unexpected expires_at header value " + expiresAt.getClass());
-    }
+    } else
+      try {
+        return Long.parseLong(expiresAt.toString());
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(
+            "Unexpected expires_at header value " + expiresAt.getClass());
+      }
   }
 
   @Override
@@ -64,11 +65,12 @@ class SpringMessageAdapter implements MessageAdapter<Message> {
       return ((Number) flags).intValue() == FLAG_REDUNDANT;
     } else if (flags instanceof String) {
       return Integer.parseInt((String) flags) == FLAG_REDUNDANT;
-    } else try {
-      return Integer.parseInt(flags.toString()) == FLAG_REDUNDANT;
-    } catch (NumberFormatException e) {
-      throw new IllegalArgumentException("Unexpected flags header value " + flags.getClass());
-    }
+    } else
+      try {
+        return Integer.parseInt(flags.toString()) == FLAG_REDUNDANT;
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException("Unexpected flags header value " + flags.getClass());
+      }
   }
 
   @Override

--- a/spring-integration/src/test/java/com/xing/beetle/spring/BeetleClientTest.java
+++ b/spring-integration/src/test/java/com/xing/beetle/spring/BeetleClientTest.java
@@ -56,12 +56,12 @@ public class BeetleClientTest {
   private static String redisServer;
 
   static {
-    GenericContainer redis = new GenericContainer("redis:3.0.2").withExposedPorts(6379);
+    GenericContainer redis = new GenericContainer("redis:4.0.14").withExposedPorts(6379);
     redis.start();
 
     List<GenericContainer> rabbitBrokers =
         IntStream.range(0, 2)
-            .mapToObj(i -> new GenericContainer("rabbitmq:3.5.3").withExposedPorts(5672))
+            .mapToObj(i -> new GenericContainer("rabbitmq:3.8.3").withExposedPorts(5672))
             .collect(Collectors.toList());
     rabbitBrokers.forEach(GenericContainer::start);
 

--- a/spring-integration/src/test/java/com/xing/beetle/spring/BeetleClientWithDeadLetteringTest.java
+++ b/spring-integration/src/test/java/com/xing/beetle/spring/BeetleClientWithDeadLetteringTest.java
@@ -53,12 +53,12 @@ public class BeetleClientWithDeadLetteringTest {
   private static String redisServer;
 
   static {
-    GenericContainer redis = new GenericContainer("redis:3.0.2").withExposedPorts(6379);
+    GenericContainer redis = new GenericContainer("redis:4.0.14").withExposedPorts(6379);
     redis.start();
 
     List<GenericContainer> rabbitBrokers =
         IntStream.range(0, 2)
-            .mapToObj(i -> new GenericContainer("rabbitmq:3.5.3").withExposedPorts(5672))
+            .mapToObj(i -> new GenericContainer("rabbitmq:3.8.3").withExposedPorts(5672))
             .collect(Collectors.toList());
     rabbitBrokers.forEach(GenericContainer::start);
 

--- a/spring-integration/src/test/java/com/xing/beetle/spring/RecordingMessageHandler.java
+++ b/spring-integration/src/test/java/com/xing/beetle/spring/RecordingMessageHandler.java
@@ -1,7 +1,5 @@
 package com.xing.beetle.spring;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.util.concurrent.*;
 import java.util.function.Supplier;
 
@@ -54,7 +52,6 @@ public class RecordingMessageHandler {
    * @param timeout maximum number of milliseconds to retry in total
    * @return final count
    */
-  @NotNull
   private Supplier<Long> countEventually(
       CopyOnWriteArrayList<String> messageList, String messageId, long expResult, long timeout) {
     return () -> {

--- a/spring-java-demo/src/main/java/com/xing/beetle/demo/Application.java
+++ b/spring-java-demo/src/main/java/com/xing/beetle/demo/Application.java
@@ -59,7 +59,7 @@ public class Application {
 
     if (countRabbitTemplate == messageCount) {
       System.out.println(
-          "Probably only there is only one broker. Deduplication does NOT work for RabbitTemplate");
+          "Probably there is only one broker. Deduplication does NOT work for RabbitTemplate");
     } else {
       System.out.println("Deduplication does NOT work for RabbitTemplate as expected.");
     }


### PR DESCRIPTION
I think the code changes herein fix the missing msgid:queue_name: prefixes on redis keys. However, since I don't full understand the code base, it would be prudent to double check this.

No attempt has yet been made to address the potential Redis garbage.