### PR TITLE
set expires key in dedup store

### DIFF
--- a/beetle-core/src/main/java/com/xing/beetle/amqp/BeetleMessageAdapter.java
+++ b/beetle-core/src/main/java/com/xing/beetle/amqp/BeetleMessageAdapter.java
@@ -87,4 +87,9 @@ public class BeetleMessageAdapter implements MessageAdapter<Delivery> {
       }
     }
   }
+
+  @Override
+  public boolean shouldNotifyException() {
+    return false;
+  }
 }

--- a/beetle-core/src/main/java/com/xing/beetle/dedup/spi/Deduplicator.java
+++ b/beetle-core/src/main/java/com/xing/beetle/dedup/spi/Deduplicator.java
@@ -51,7 +51,7 @@ public interface Deduplicator {
 
   void deleteKeys(String messageId);
 
-  boolean initKeys(String messageId);
+  boolean initKeys(String messageId, long expirationTimeSecs);
 
   BeetleAmqpConfiguration getBeetleAmqpConfiguration();
 
@@ -93,7 +93,7 @@ public interface Deduplicator {
           String.format("Beetle: ignored completed message %s", adapter.keyOf(message)));
     } else {
       if (tryAcquireMutex(key, getBeetleAmqpConfiguration().getMutexExpiration())) {
-        initKeys(adapter.keyOf(message));
+        initKeys(adapter.keyOf(message), adapter.expiresAt(message));
         if (completed(key)) {
           dropMessage(
               message,

--- a/beetle-core/src/main/java/com/xing/beetle/dedup/spi/KeyValueStore.java
+++ b/beetle-core/src/main/java/com/xing/beetle/dedup/spi/KeyValueStore.java
@@ -21,7 +21,7 @@ public interface KeyValueStore {
 
     private String text;
 
-    long getAsNumber() {
+    public long getAsNumber() {
       return Long.parseLong(text);
     }
 

--- a/beetle-core/src/main/java/com/xing/beetle/dedup/spi/KeyValueStore.java
+++ b/beetle-core/src/main/java/com/xing/beetle/dedup/spi/KeyValueStore.java
@@ -1,5 +1,6 @@
 package com.xing.beetle.dedup.spi;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -35,9 +36,11 @@ public interface KeyValueStore {
 
   boolean putIfAbsentTtl(String key, Value value, int secondsToExpire);
 
+  boolean putIfAbsent(Map<String, Value> keysValues);
+
   void put(String key, Value value);
 
-  void delete(String... keys);
+  void deleteMultiple(String... keys);
 
   long increase(String key);
 }

--- a/beetle-core/src/main/java/com/xing/beetle/dedup/spi/KeyValueStoreBasedDeduplicator.java
+++ b/beetle-core/src/main/java/com/xing/beetle/dedup/spi/KeyValueStoreBasedDeduplicator.java
@@ -3,6 +3,7 @@ package com.xing.beetle.dedup.spi;
 import com.xing.beetle.amqp.BeetleAmqpConfiguration;
 import com.xing.beetle.dedup.spi.KeyValueStore.Value;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -99,8 +100,8 @@ public class KeyValueStoreBasedDeduplicator implements Deduplicator {
     keysValues.put(
         key(messageId, EXPIRES),
         new Value(
-            System.currentTimeMillis()
-                + this.beetleAmqpConfig.getBeetleRedisStatusKeyExpiryIntervalSeconds() * 1000));
+                Instant.now().getEpochSecond()
+                + this.beetleAmqpConfig.getMessageLifetimeSeconds()));
     return store.putIfAbsent(keysValues);
   }
 

--- a/beetle-core/src/main/java/com/xing/beetle/dedup/spi/KeyValueStoreBasedDeduplicator.java
+++ b/beetle-core/src/main/java/com/xing/beetle/dedup/spi/KeyValueStoreBasedDeduplicator.java
@@ -4,6 +4,8 @@ import com.xing.beetle.amqp.BeetleAmqpConfiguration;
 import com.xing.beetle.dedup.spi.KeyValueStore.Value;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
@@ -42,17 +44,10 @@ public class KeyValueStoreBasedDeduplicator implements Deduplicator {
 
   @Override
   public boolean completed(String messageId) {
-    if (store.putIfAbsentTtl(
-        key(messageId, STATUS),
-        new Value("incomplete"),
-        beetleAmqpConfig.getBeetleRedisStatusKeyExpiryIntervalSeconds())) {
-      return false;
-    } else {
-      return store
-          .get(key(messageId, STATUS))
-          .map(value -> value.getAsString().equals("completed"))
-          .orElse(false);
-    }
+    return store
+        .get(key(messageId, STATUS))
+        .map(value -> value.getAsString().equals("completed"))
+        .orElse(false);
   }
 
   @Override
@@ -90,7 +85,23 @@ public class KeyValueStoreBasedDeduplicator implements Deduplicator {
         (beetleAmqpConfig.getBeetleRedisStatusKeyExpiryIntervalSeconds() > 0)
             ? Arrays.stream(keySuffixes).filter(s -> !s.equals(STATUS))
             : Arrays.stream(keySuffixes);
-    store.delete(suffixStream.map(s -> key(messageId, s)).toArray(String[]::new));
+    store.deleteMultiple(suffixStream.map(s -> key(messageId, s)).toArray(String[]::new));
+  }
+
+  /**
+   * returns true if the initialization succeeds, i.e. there were no already existing STATUS and
+   * EXPIRES keys. return false if at least one of STATUS and EXPIRES keys already exists.
+   */
+  @Override
+  public boolean initKeys(String messageId) {
+    Map<String, Value> keysValues = new HashMap<>();
+    keysValues.put(key(messageId, STATUS), new Value("incomplete"));
+    keysValues.put(
+        key(messageId, EXPIRES),
+        new Value(
+            System.currentTimeMillis()
+                + this.beetleAmqpConfig.getBeetleRedisStatusKeyExpiryIntervalSeconds() * 1000));
+    return store.putIfAbsent(keysValues);
   }
 
   @Override

--- a/beetle-core/src/main/java/com/xing/beetle/dedup/spi/KeyValueStoreBasedDeduplicator.java
+++ b/beetle-core/src/main/java/com/xing/beetle/dedup/spi/KeyValueStoreBasedDeduplicator.java
@@ -3,7 +3,6 @@ package com.xing.beetle.dedup.spi;
 import com.xing.beetle.amqp.BeetleAmqpConfiguration;
 import com.xing.beetle.dedup.spi.KeyValueStore.Value;
 
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -94,14 +93,10 @@ public class KeyValueStoreBasedDeduplicator implements Deduplicator {
    * EXPIRES keys. return false if at least one of STATUS and EXPIRES keys already exists.
    */
   @Override
-  public boolean initKeys(String messageId) {
+  public boolean initKeys(String messageId, long expirationTimeSecs) {
     Map<String, Value> keysValues = new HashMap<>();
     keysValues.put(key(messageId, STATUS), new Value("incomplete"));
-    keysValues.put(
-        key(messageId, EXPIRES),
-        new Value(
-                Instant.now().getEpochSecond()
-                + this.beetleAmqpConfig.getMessageLifetimeSeconds()));
+    keysValues.put(key(messageId, EXPIRES), new Value(expirationTimeSecs));
     return store.putIfAbsent(keysValues);
   }
 

--- a/beetle-core/src/main/java/com/xing/beetle/dedup/spi/MessageAdapter.java
+++ b/beetle-core/src/main/java/com/xing/beetle/dedup/spi/MessageAdapter.java
@@ -11,4 +11,6 @@ public interface MessageAdapter<M> {
   long expiresAt(M message);
 
   boolean isRedundant(M message);
+
+  boolean shouldNotifyException();
 }

--- a/beetle-core/src/test/java/com/xing/beetle/MultiPlexingConnectionIT.java
+++ b/beetle-core/src/test/java/com/xing/beetle/MultiPlexingConnectionIT.java
@@ -5,7 +5,6 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.ConnectionFactory;
 import com.xing.beetle.amqp.BeetleAmqpConfiguration;
 import com.xing.beetle.amqp.MultiPlexingConnection;
-
 import com.xing.beetle.dedup.spi.Deduplicator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -81,6 +80,11 @@ public class MultiPlexingConnectionIT {
 
               @Override
               public void deleteKeys(String messageId) {}
+
+              @Override
+              public boolean initKeys(String messageId) {
+                return false;
+              }
 
               @Override
               public BeetleAmqpConfiguration getBeetleAmqpConfiguration() {

--- a/beetle-core/src/test/java/com/xing/beetle/MultiPlexingConnectionIT.java
+++ b/beetle-core/src/test/java/com/xing/beetle/MultiPlexingConnectionIT.java
@@ -82,7 +82,7 @@ public class MultiPlexingConnectionIT {
               public void deleteKeys(String messageId) {}
 
               @Override
-              public boolean initKeys(String messageId) {
+              public boolean initKeys(String messageId, long expirationTime) {
                 return false;
               }
 

--- a/beetle-core/src/test/java/com/xing/beetle/dedup/DeduplicatorTest.java
+++ b/beetle-core/src/test/java/com/xing/beetle/dedup/DeduplicatorTest.java
@@ -1,0 +1,122 @@
+package com.xing.beetle.dedup;
+
+import com.xing.beetle.amqp.BeetleAmqpConfiguration;
+import com.xing.beetle.dedup.api.MessageListener;
+import com.xing.beetle.dedup.spi.Deduplicator;
+import com.xing.beetle.dedup.spi.KeyValueStore;
+import com.xing.beetle.dedup.spi.KeyValueStoreBasedDeduplicator;
+import com.xing.beetle.dedup.spi.MessageAdapter;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class DeduplicatorTest {
+
+  static class TestMessage {}
+
+  @Mock private MessageAdapter<TestMessage> messageAdapter;
+
+  @Mock private MessageListener<TestMessage> messageListener;
+
+  @Mock private KeyValueStore keyValueStore;
+
+  @Test
+  public void test_redundantMessagesProcessedOnceSuccessfully() throws Throwable {
+
+    MockitoAnnotations.initMocks(this);
+
+    TestMessage message = new TestMessage();
+    when(messageAdapter.isRedundant(any())).thenReturn(true);
+    when(messageAdapter.keyOf(eq(message))).thenReturn("msgid:queue:test-message-id");
+    when(keyValueStore.putIfAbsentTtl(
+            eq("msgid:queue:test-message-id:mutex"), any(KeyValueStore.Value.class), anyInt()))
+        .thenReturn(true);
+    when(keyValueStore.putIfAbsentTtl(
+            eq("msgid:queue:test-message-id:status"), any(KeyValueStore.Value.class), anyInt()))
+        .thenReturn(true);
+
+    Deduplicator deduplicator =
+        new KeyValueStoreBasedDeduplicator(keyValueStore, new BeetleAmqpConfiguration());
+    deduplicator.handle(message, messageAdapter, messageListener);
+
+    ArgumentCaptor<KeyValueStore.Value> captor = ArgumentCaptor.forClass(KeyValueStore.Value.class);
+    verify(keyValueStore, times(1)).put(eq("msgid:queue:test-message-id:status"), captor.capture());
+    assertEquals("completed", captor.getValue().getAsString());
+
+    // mutex should be released after completion
+    verify(keyValueStore).delete(eq("msgid:queue:test-message-id:mutex"));
+    verify(keyValueStore, times(1)).increase(eq("msgid:queue:test-message-id:ack_count"));
+
+    when(keyValueStore.get(eq("msgid:queue:test-message-id:status")))
+        .thenReturn(java.util.Optional.of(new KeyValueStore.Value("completed")));
+    when(keyValueStore.increase(eq("msgid:queue:test-message-id:ack_count"))).thenReturn(2L);
+    // same (redundant) message which was completed is received by deduplicator again
+    deduplicator.handle(message, messageAdapter, messageListener);
+
+    // we should get 2 ACKs in total, 1 for each message
+    verify(keyValueStore, times(2)).increase(eq("msgid:queue:test-message-id:ack_count"));
+
+    // verify that the message is processed only once
+    verify(messageListener, times(1)).onMessage(eq(message));
+
+    verifyKeyCleanUp();
+  }
+
+  public void verifyKeyCleanUp() {
+    ArgumentCaptor<String> varargCaptor = ArgumentCaptor.forClass(String.class);
+    // verify cleaning up  keys
+    verify(keyValueStore).deleteMultiple(varargCaptor.capture());
+    assertArrayEquals(
+        Arrays.stream(Deduplicator.keySuffixes)
+            .map(s -> "msgid:queue:test-message-id:" + s)
+            .toArray(),
+        varargCaptor.getAllValues().toArray());
+  }
+
+  @Captor private ArgumentCaptor<Map<String, KeyValueStore.Value>> argCaptor;
+
+  @Test
+  public void test_redundantMessageFail_shouldBeRequeued() throws Throwable {
+
+    MockitoAnnotations.initMocks(this);
+
+    TestMessage message = new TestMessage();
+    when(messageAdapter.isRedundant(any())).thenReturn(true);
+    when(messageAdapter.keyOf(eq(message))).thenReturn("msgid:queue:test-message-id");
+    when(keyValueStore.putIfAbsentTtl(
+            eq("msgid:queue:test-message-id:mutex"), any(KeyValueStore.Value.class), anyInt()))
+        .thenReturn(true);
+    when(keyValueStore.putIfAbsent(anyMap())).thenReturn(true);
+
+    doThrow(new InterruptedException()).when(messageListener).onMessage(message);
+
+    BeetleAmqpConfiguration beetleAmqpConfig = new BeetleAmqpConfiguration();
+    beetleAmqpConfig.setMaxHandlerExecutionAttempts(3);
+    beetleAmqpConfig.setExceptionLimit(3);
+    Deduplicator deduplicator = new KeyValueStoreBasedDeduplicator(keyValueStore, beetleAmqpConfig);
+    deduplicator.handle(message, messageAdapter, messageListener);
+
+    verify(keyValueStore, times(1)).putIfAbsent(argCaptor.capture());
+
+    Map<String, KeyValueStore.Value> initArgs = argCaptor.getValue();
+    assertEquals("incomplete", initArgs.get("msgid:queue:test-message-id:status").getAsString());
+    assertTrue(initArgs.containsKey("msgid:queue:test-message-id:expires"));
+
+    verify(keyValueStore, times(1)).increase(eq("msgid:queue:test-message-id:exceptions"));
+    verify(keyValueStore, times(1)).increase(eq("msgid:queue:test-message-id:attempts"));
+    verify(keyValueStore, times(1)).put(eq("msgid:queue:test-message-id:delay"), any());
+    verify(messageAdapter, times(1)).requeue(message);
+
+    // mutex should be released after completion
+    verify(keyValueStore).delete(eq("msgid:queue:test-message-id:mutex"));
+  }
+}

--- a/spring-integration/src/main/java/com/xing/beetle/spring/SpringMessageAdapter.java
+++ b/spring-integration/src/main/java/com/xing/beetle/spring/SpringMessageAdapter.java
@@ -87,4 +87,9 @@ class SpringMessageAdapter implements MessageAdapter<Message> {
       }
     }
   }
+
+  @Override
+  public boolean shouldNotifyException() {
+    return true;
+  }
 }


### PR DESCRIPTION
make sure that expires key is set when a message key is first put into the dedup store so that it can be cleaned up externally if needed later.