### PR TITLE
skip simple message check before key cleanup from Redis for now. 

### DIFF
--- a/beetle-core/src/main/java/com/xing/beetle/dedup/spi/Deduplicator.java
+++ b/beetle-core/src/main/java/com/xing/beetle/dedup/spi/Deduplicator.java
@@ -197,11 +197,8 @@ public interface Deduplicator {
    * the last message with this message id.
    */
   private <M> void cleanUp(M message, MessageAdapter<M> adapter) {
-    if (getBeetleAmqpConfiguration().getMaxHandlerExecutionAttempts() > 1
-        || adapter.isRedundant(message)) {
-      if (!adapter.isRedundant(message) || incrementAckCount(adapter.keyOf(message)) >= 2) {
-        deleteKeys(adapter.keyOf(message));
-      }
+    if (!adapter.isRedundant(message) || incrementAckCount(adapter.keyOf(message)) >= 2) {
+      deleteKeys(adapter.keyOf(message));
     }
   }
 


### PR DESCRIPTION
This should be reactivated after simple message optimization.