### PR TITLE
Downgrade minimum Spring framework version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>9</maven.compiler.release>
-        <spring.version>2.3.3.RELEASE</spring.version>
-        <spring.rabbit.test.version>2.2.10.RELEASE</spring.rabbit.test.version>
+        <spring.version>2.2.0.RELEASE</spring.version>
+        <spring.rabbit.test.version>2.2.0.RELEASE</spring.rabbit.test.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>9</maven.compiler.release>
-        <spring.version>2.2.0.RELEASE</spring.version>
-        <spring.rabbit.test.version>2.2.0.RELEASE</spring.rabbit.test.version>
+        <spring.version>2.2.1.RELEASE</spring.version>
+        <spring.rabbit.test.version>2.2.1.RELEASE</spring.rabbit.test.version>
     </properties>
 
     <modules>

--- a/spring-integration/src/main/java/com/xing/beetle/spring/BeetleAutoConfiguration.java
+++ b/spring-integration/src/main/java/com/xing/beetle/spring/BeetleAutoConfiguration.java
@@ -66,7 +66,7 @@ public class BeetleAutoConfiguration {
           .asInt(Duration::getSeconds)
           .to(factory::setRequestedHeartbeat);
       RabbitProperties.Ssl ssl = properties.getSsl();
-      if (ssl.determineEnabled()) {
+      if (ssl.isEnabled()) {
         factory.setUseSSL(true);
         map.from(ssl::getAlgorithm).whenNonNull().to(factory::setSslAlgorithm);
         map.from(ssl::getKeyStoreType).to(factory::setKeyStoreType);

--- a/spring-integration/src/main/java/com/xing/beetle/spring/BeetleAutoConfiguration.java
+++ b/spring-integration/src/main/java/com/xing/beetle/spring/BeetleAutoConfiguration.java
@@ -66,7 +66,7 @@ public class BeetleAutoConfiguration {
           .asInt(Duration::getSeconds)
           .to(factory::setRequestedHeartbeat);
       RabbitProperties.Ssl ssl = properties.getSsl();
-      if (ssl.isEnabled()) {
+      if (ssl.determineEnabled()) {
         factory.setUseSSL(true);
         map.from(ssl::getAlgorithm).whenNonNull().to(factory::setSslAlgorithm);
         map.from(ssl::getKeyStoreType).to(factory::setKeyStoreType);

--- a/spring-java-demo/pom.xml
+++ b/spring-java-demo/pom.xml
@@ -23,4 +23,17 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <!--                Spring Boot version can be overridden as shown here-->
+                <version>2.3.4.RELEASE</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/spring-java-demo/pom.xml
+++ b/spring-java-demo/pom.xml
@@ -29,7 +29,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <!--                Spring Boot version can be overridden as shown here-->
+                <!--Spring Boot version can be overridden as shown here-->
                 <version>2.3.4.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/spring-kotlin-demo/pom.xml
+++ b/spring-kotlin-demo/pom.xml
@@ -11,10 +11,17 @@
 
     <properties>
         <kotlin.version>1.3.72</kotlin.version>
+        <spring.version>2.3.4.RELEASE</spring.version>
     </properties>
 
     <artifactId>kotlin-spring-demo</artifactId>
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.xing.beetle</groupId>
             <artifactId>spring-integration</artifactId>
@@ -80,6 +87,4 @@
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/spring-kotlin-demo/pom.xml
+++ b/spring-kotlin-demo/pom.xml
@@ -20,6 +20,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot</artifactId>
+            <!--Spring Boot version can be overridden as shown here-->
             <version>${spring.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Downgrades the spring dependencies to `2.2.1.RELEASE` to aviod forcing consumers to upgrade.

`2.2.1.RELEASE` is the version that introduces the method `org.springframework.boot.autoconfigure.amqp.RabbitProperties.Ssl#determineEnabled()` that is used by more recent framework versions.
