### PR TITLE
speed up test suite

### DIFF
--- a/beetle-core/src/test/java/com/xing/beetle/BaseBeetleIT.java
+++ b/beetle-core/src/test/java/com/xing/beetle/BaseBeetleIT.java
@@ -26,7 +26,8 @@ class BaseBeetleIT {
 
   private static Address addressOf(RabbitMQContainer container) {
     String amqpUrl = container.getAmqpUrl();
-    return Address.parseAddress(amqpUrl.substring(7));
+    String address = amqpUrl.substring(7).replace("localhost", "127.0.0.1");
+    return Address.parseAddress(address);
   }
 
   static Stream<Connection> createConnections(

--- a/beetle-core/src/test/java/com/xing/beetle/BeetleAcceptanceIT.java
+++ b/beetle-core/src/test/java/com/xing/beetle/BeetleAcceptanceIT.java
@@ -24,11 +24,7 @@ class BeetleAcceptanceIT extends BaseBeetleIT {
   private GenericContainer<?> redis;
 
   private static String getRedisAddress(GenericContainer<?> redisContainer) {
-    return String.join(
-        ":",
-        new String[] {
-          redisContainer.getContainerIpAddress(), redisContainer.getFirstMappedPort() + ""
-        });
+    return "127.0.0.1:" + redisContainer.getFirstMappedPort();
   }
 
   public BeetleAcceptanceIT() {
@@ -207,7 +203,7 @@ class BeetleAcceptanceIT extends BaseBeetleIT {
 
     List<String> rabbitAddresses =
         TestContainerProvider.rabbitMQContainers.stream()
-            .map(rabbit -> rabbit.getContainerIpAddress() + ":" + rabbit.getFirstMappedPort())
+            .map(rabbit -> "127.0.0.1:" + rabbit.getFirstMappedPort())
             .limit(containers)
             .collect(Collectors.toList());
 

--- a/beetle-core/src/test/java/com/xing/beetle/MultiPlexingConnectionIT.java
+++ b/beetle-core/src/test/java/com/xing/beetle/MultiPlexingConnectionIT.java
@@ -31,7 +31,7 @@ public class MultiPlexingConnectionIT {
     RabbitMQContainer container = TestContainerProvider.rabbitMQContainers.get(0);
     container.start();
     ConnectionFactory factory = new ConnectionFactory();
-    factory.setHost(container.getContainerIpAddress());
+    factory.setHost("127.0.0.1");
     factory.setPort(container.getAmqpPort());
     channel = createChannel(factory);
   }

--- a/beetle-core/src/test/java/com/xing/beetle/RequeueAtEndConnectionIT.java
+++ b/beetle-core/src/test/java/com/xing/beetle/RequeueAtEndConnectionIT.java
@@ -52,12 +52,12 @@ class RequeueAtEndConnectionIT {
       throws Exception {
     int processMessageCount = 0;
     ConnectionFactory factory = new ConnectionFactory();
-    factory.setHost(container.getContainerIpAddress());
+    factory.setHost("127.0.0.1");
     factory.setPort(container.getAmqpPort());
 
     BeetleAmqpConfiguration beetleAmqpConfiguration = beetleAmqpConfiguration();
     when(beetleAmqpConfiguration.getBeetleServers())
-        .thenReturn(container.getContainerIpAddress() + ":" + container.getAmqpPort());
+        .thenReturn("127.0.0.1:" + container.getAmqpPort());
     if (requeueDelay >= 0) {
       when(beetleAmqpConfiguration.getDeadLetteringMsgTtlMs()).thenReturn(requeueDelay);
       when(beetleAmqpConfiguration.isDeadLetteringEnabled()).thenReturn(true);

--- a/spring-integration/src/test/java/com/xing/beetle/spring/BeetleClientTest.java
+++ b/spring-integration/src/test/java/com/xing/beetle/spring/BeetleClientTest.java
@@ -73,13 +73,11 @@ public class BeetleClientTest {
 
     List<String> rabbitAddresses =
         rabbitBrokers.stream()
-            .map(rabbit -> rabbit.getContainerIpAddress() + ":" + rabbit.getFirstMappedPort())
+            .map(rabbit -> "127.0.0.1:" + rabbit.getFirstMappedPort())
             .collect(Collectors.toList());
 
     beetleServers = String.join(",", rabbitAddresses);
-    redisServer =
-        String.join(
-            ":", new String[] {redis.getContainerIpAddress(), redis.getFirstMappedPort() + ""});
+    redisServer = "127.0.0.1:" + redis.getFirstMappedPort();
 
     System.setProperty("test.deadLetterEnabled", "false");
   }

--- a/spring-integration/src/test/java/com/xing/beetle/spring/BeetleClientWithDeadLetteringTest.java
+++ b/spring-integration/src/test/java/com/xing/beetle/spring/BeetleClientWithDeadLetteringTest.java
@@ -70,13 +70,11 @@ public class BeetleClientWithDeadLetteringTest {
 
     List<String> rabbitAddresses =
         rabbitBrokers.stream()
-            .map(rabbit -> rabbit.getContainerIpAddress() + ":" + rabbit.getFirstMappedPort())
+            .map(rabbit -> "127.0.0.1:" + rabbit.getFirstMappedPort())
             .collect(Collectors.toList());
 
     beetleServers = String.join(",", rabbitAddresses);
-    redisServer =
-        String.join(
-            ":", new String[] {redis.getContainerIpAddress(), redis.getFirstMappedPort() + ""});
+    redisServer = "127.0.0.1:" + redis.getFirstMappedPort().toString();
 
     System.setProperty("test.deadLetterEnabled", "true");
   }


### PR DESCRIPTION
On some Macs, the full test suite takes more than 15 minutes to run. This is caused by using "localhost" when connecting to docker containers. Relacing getContainerIpAdress() with "127.0.0.1" fixes the problem. Apparently this has something to do with IPV6 where localhost is resolved to ::1 and trying to connect to ::1:port leads to a timeout when the process listening on that address is a docker container.