### PR TITLE
make sure all messages sent by the client have a message id

### DIFF
--- a/beetle-core/src/main/java/com/xing/beetle/amqp/BeetleChannel.java
+++ b/beetle-core/src/main/java/com/xing/beetle/amqp/BeetleChannel.java
@@ -125,7 +125,7 @@ public class BeetleChannel implements DefaultChannel.Decorator {
     }
 
     int redundancy = (int) props.getHeaders().getOrDefault(BeetleHeader.PUBLISH_REDUNDANCY, 1);
-    if (redundancy > 1 && props.getMessageId() == null) {
+    if (props.getMessageId() == null) {
       props = props.builder().messageId(UUID.randomUUID().toString()).build();
     }
 


### PR DESCRIPTION
It is not only redundant messages that need a message id. Message consumers that need to access the deduplication store always need one. On top of that, we always want to be able to log a message id.